### PR TITLE
Qol new context menu options

### DIFF
--- a/background.js
+++ b/background.js
@@ -101,7 +101,7 @@ var bg = {
             chrome.tabs.query({windowId: windowId, active: true}, function (tabs) {
                 var selectedTab = tabs[0];
                 if (selectedTab) {
-                    chrome.browserAction.setIcon({path: iconName, tabId: selectedTab.id});
+                    chrome.browserAction.setIcon({ path: iconName });
                 }
             });
         }

--- a/background.js
+++ b/background.js
@@ -106,8 +106,37 @@ var bg = {
             });
         }
     }
-
 }
 
+function goToJiraTimer(goToBoard = false) {
+  chrome.storage.local.get((res) => {
+    const keys = $.grep(Object.keys(res), function(el) {
+      return el.indexOf('-') > -1;
+    });
+    if (keys.length === 0 || goToBoard) {
+      const regex = /\w(?:[^@\n]+@)?(?:www\.)?([^:\/\n]+)/im;
+      const manifestURLMatch = chrome.runtime.getManifest().content_scripts[0].matches[0];
+      let m;
+      if ((m = regex.exec(manifestURLMatch)) !== null) {
+        chrome.tabs.create({url: `https://${m[0]}`, active: true}, function(){});
+      }
+    } else {
+      chrome.tabs.create({url: res[keys[0]].url, active: true}, function(){});
+    }
+  });
+}
 
+chrome.contextMenus.create({ title: 'Go To Jira Timer', id: 'goToJiraTimer', contexts: ['browser_action']});
+chrome.contextMenus.create({ title: 'Go To Jira', id: 'goToJira', contexts: ['browser_action'] });
+chrome.contextMenus.onClicked.addListener((obj) => {
+  if (obj.menuItemId === 'goToJiraTimer') {
+    goToJiraTimer();
+  }
+  if (obj.menuItemId === 'goToJira') {
+    goToJiraTimer(true);
+  }
+});
+chrome.browserAction.onClicked.addListener((obj) => {
+  goToJiraTimer();
+});
 

--- a/jiraTimer.js
+++ b/jiraTimer.js
@@ -311,5 +311,3 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     }
 });
 
-
-

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
     "persistent": false
   },
   "content_scripts": [{
-    "matches": ["*://jira.REPLACE-WITH-YOUR-ORG-DOMAIN/*"],
+    "matches": ["*://jira.ties.k12.mn.us/*"],
     "js": ["third-party/js/jquery-3.1.1.min.js", "third-party/js/moment.min.js", "third-party/js/toastr.min.js", "third-party/js/anime.min.js", "jiraTimer.js"],
     "css": ["third-party/css/toastr.min.css", "jiraTimer.css"]
   }],
@@ -23,7 +23,7 @@
     "default_title": "Jira Timer"
   },
   "permissions": [
-    "tabs", "background", "storage", "*://jira.REPLACE-WITH-YOUR-ORG-DOMAIN/*"
+    "tabs", "background", "storage", "*://jira.ties.k12.mn.us/*"
   ],
   "web_accessible_resources": [
     "active_19.png", "inactive_19.png", "code2coffee2.gif"

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
     "persistent": false
   },
   "content_scripts": [{
-    "matches": ["*://jira.ties.k12.mn.us/*"],
+    "matches": ["*://jira.REPLACE-WITH-YOUR-ORG-DOMAIN/*"],
     "js": ["third-party/js/jquery-3.1.1.min.js", "third-party/js/moment.min.js", "third-party/js/toastr.min.js", "third-party/js/anime.min.js", "jiraTimer.js"],
     "css": ["third-party/css/toastr.min.css", "jiraTimer.css"]
   }],
@@ -23,7 +23,7 @@
     "default_title": "Jira Timer"
   },
   "permissions": [
-    "tabs", "background", "storage", "*://jira.ties.k12.mn.us/*"
+    "contextMenus", "tabs", "background", "storage", "*://jira.REPLACE-WITH-YOUR-ORG-DOMAIN/*"
   ],
   "web_accessible_resources": [
     "active_19.png", "inactive_19.png", "code2coffee2.gif"


### PR DESCRIPTION
This adds two right-click options on the icon to go to either the board, or the issue you're currently working on.  Also the left click of the button goes to the issue you're working on, or the board if you aren't working on an issue.
I added a regex to parse the url from the manifest, because you have omitted it from being part of the source (for security reasons I assume), but it is not a very robust regex, and works with our current domain, but not sure about others.